### PR TITLE
Upgrade golang and codegen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN apk update \
  && update-ca-certificates
 
 RUN CGO_ENABLED=0 \
-    go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.12.0 \
+    go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.12 \
  && /go/bin/oapi-codegen -version
 
 FROM scratch \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
 
-FROM golang:1.17-alpine \
+FROM golang:1.20-alpine \
   AS build
 
 ENV USER=appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 #   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #   SOFTWARE.
 
-FROM golang:1.20-alpine \
+FROM golang:1.17-alpine \
   AS build
 
 ENV USER=appuser
@@ -44,7 +44,7 @@ RUN apk update \
  && update-ca-certificates
 
 RUN CGO_ENABLED=0 \
-    go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.12 \
+    go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.12.4 \
  && /go/bin/oapi-codegen -version
 
 FROM scratch \


### PR DESCRIPTION
Hi,

Thank you for making this Docker file -- it's just what I needed, with a couple of minor changes:
1. I've gone with go lang 1.20
2. I've let docker pick the latest patch release of `oapi-codegen` 1.12 (today it is 1.12.4)
